### PR TITLE
Update URL handling

### DIFF
--- a/sub/index.php
+++ b/sub/index.php
@@ -10,7 +10,11 @@ $isTextHTML=str_contains(($_SERVER['HTTP_ACCEPT']??''),'text/html');
 
 const BASE_URL="https://YOUR_IP:PORT"; // Replace IP address and port
 
-$URL=BASE_URL.$_SERVER['SCRIPT_URL']??'';
+if(isset($_SERVER['SCRIPT_URL']) && !empty($_SERVER['SCRIPT_URL'])) {
+    $URL = BASE_URL.$_SERVER['SCRIPT_URL'];
+} else {
+    $URL = BASE_URL.$_SERVER['REQUEST_URI'];
+}
 $URL .= $isTextHTML?'/info':'';
 
 $ch = curl_init();


### PR DESCRIPTION
This commit addresses a URL handling issue in the main page (`index.php`). Previously, the code on line 13 was using `$_SERVER['SCRIPT_URL']` to retrieve the URL, but this variable is not always defined. This led to inconsistencies in URL generation.

Changes Made:
- Modified 'index.php' on line 13 to use `$_SERVER['REQUEST_URI']` if `$_SERVER['SCRIPT_URL']` is not defined.

Closure of Issues:
- Closes #1 
- Closes #3 